### PR TITLE
Fix Include Source

### DIFF
--- a/build/src/lib.rs
+++ b/build/src/lib.rs
@@ -98,7 +98,7 @@ impl MdDioxusArtifact {
         // rust
         fs::write(
             path.join(format!("{}.rs", self.name)),
-            format!("{}", self.content),
+            format!("{{ {} }}", self.content),
         )
         .unwrap();
     }


### PR DESCRIPTION
Fix the `include!` source by coercing it into a single expression.